### PR TITLE
Create Dockerfile and add running in docker instruction to README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:3.11
+
+WORKDIR /code
+
+COPY ./requirements.txt /code/requirements.txt
+
+RUN pip install --no-cache-dir --upgrade -r /code/requirements.txt
+
+COPY ./trained_models/model.pth /code/trained_models/model.pth
+COPY ./Model.py /code/Model.py
+COPY ./predict.py /code/predict.py
+
+
+CMD ["python", "predict.py"]

--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ The Godot engine project in `godot_project/` provides a user interface for inter
    - The UI will interact with `predict.py` via http requests for real-time digit recognition.
 
 
+### Optionally: running in Docker
+
+To run in docker, first build a docker image:
+```shell
+docker build -t handwritten-img .
+```
+
+Then run docker container with port redirected:
+```shell
+docker run -d --name handwritten -p 8001:8000 handwritten-img
+```
+
 ## Example Digits Recognized
 
 ![img.png](readme_assets/example_recognitions.png)


### PR DESCRIPTION
This is alternative way of running model backend, as a docker container, suitable for running in a bigger, ML-API system.

A staightforwart run-in-terminal option is still available for easy debugging